### PR TITLE
feat(epic-0/us-0.1): remove template placeholders, set project name t…

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -8,7 +8,7 @@
 
 # ---------------------------------------------------------------------------
 [app]
-name       = "AuriPostao_tao_seed"
+name       = "AuriPostao"
 version    = "0.1.0"
 mode       = "debug"   # debug | normal
 language   = "fr"
@@ -26,7 +26,7 @@ strict_mode         = false
 # Any path outside these roots will be rejected at runtime.
 allowed_roots = [
   "$HOME/Downloads",
-  "/Users/phil/Library/CloudStorage/Dropbox/devwww/app/AuriPostao_tao_seed"
+  "/Users/phil/Library/CloudStorage/Dropbox/devwww/app/AuriPostao"
 ]
 
 # Runtime directories — created automatically on first run.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "{{ PROJECT_NAME_LOWER }}",
+  "name": "auripostao",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "{{ PROJECT_NAME_LOWER }}",
+      "name": "auripostao",
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "{{ PROJECT_NAME_LOWER }}",
+  "name": "auripostao",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
     "windows": [
       {
         "label": "main",
-        "title": "{{ PROJECT_NAME }}",
+        "title": "AuriPostao",
         "width": 1200,
         "height": 800,
         "resizable": true,
@@ -29,5 +29,5 @@
       }
     ]
   },
-  "identifier": "fr.phil.{{ PROJECT_NAME_LOWER }}"
+  "identifier": "fr.phil.auripostao"
 }


### PR DESCRIPTION
…o AuriPostao

- package.json: PROJECT_NAME_LOWER -> auripostao
- package-lock.json: regenerated with correct name
- src-tauri/tauri.conf.json: PROJECT_NAME -> AuriPostao, identifier updated
- config/default.toml: app.name and allowed_roots updated

Closes #1